### PR TITLE
Feature/relax l version constraints

### DIFF
--- a/examples/example1/example.tf
+++ b/examples/example1/example.tf
@@ -1,6 +1,6 @@
 module "azdo_naming" {
   source  = "DownAtTheBottomOfTheMoleHole/naming/azuredevops"
-  version = "~> 2.2.0"
+  version = ">= 6.0.0, <7.0.0"
 
   # Optional variables
   environment_tags = [

--- a/examples/example2/example.tf
+++ b/examples/example2/example.tf
@@ -1,6 +1,6 @@
 module "azdo_naming" {
   source  = "DownAtTheBottomOfTheMoleHole/naming/azuredevops"
-  version = "~> 2.2.0"
+  version = ">=6.0.0, <7.0.0"
 
   # Optional variables
   environment_tags = [


### PR DESCRIPTION
This pull request updates the version constraints for the `azdo_naming` module in two example Terraform files. The changes ensure compatibility with more recent versions of the module.

* [`examples/example1/example.tf`](diffhunk://#diff-cbdb9248e97b0344f446b66b945dafff49a5cf855215b98700dc3020b639a1eeL3-R3): Updated the version constraint for the `azdo_naming` module to `>= 6.0.0, <7.0.0`.
* [`examples/example2/example.tf`](diffhunk://#diff-dff106885cbaeec069f0b9925b2f04e8ba18f555f6bf80dae5564c9ecd695b43L3-R3): Updated the version constraint for the `azdo_naming` module to `>= 6.0.0, <7.0.0`.