### PR TITLE
test: 🧪 add native terraform test scaffold (v11 checkpoint 1/11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,61 @@
+---
+name: terraform-tests
+
+# Native `terraform test` runs that gate every pull request and every push
+# to a release branch. The module ships only `random` provider config, so
+# tests run without any cloud credentials.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "**.tf"
+      - "tests/**"
+      - ".github/workflows/test.yml"
+  push:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "**.tf"
+      - "tests/**"
+      - ".github/workflows/test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-test:
+    name: terraform test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform_version:
+          - "1.14.0"  # required_version floor
+          - "latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform ${{ matrix.terraform_version }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform_version }}
+          terraform_wrapper: false
+
+      - name: Terraform fmt (check)
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        run: terraform init -backend=false -input=false
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform test
+        run: terraform test -verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,13 @@ repos:
         args:
           - --hook-config=--retry-once-with-cleanup=true # Boolean. true or false
 
+      # run native `terraform test` against the .tftest.hcl files in tests/
+      # to gate every commit against regression in the naming logic
+      - id: terraform_test
+        name: Run terraform test against the tests/ suite
+        args:
+          - --hook-config=--retry-once-with-cleanup=true
+
       ##############################################################
       #######        Terraform version updates               #######
       ##############################################################

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ locals {
 
   }
 
-  translated_environment_tags = [for tag in local.unique_environment_tags : lookup(local.environment_mapping, tag, tag)]
+  translated_environment_tags = distinct([for tag in local.unique_environment_tags : lookup(local.environment_mapping, tag, tag)])
 
   ## Names based on the recommendations of
   ## https://learn.microsoft.com/en-us/azure/devops/organizations/settings/naming-restrictions?view=azure-devops

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,42 @@
+# Tests
+
+This directory contains the [native `terraform test`](https://developer.hashicorp.com/terraform/language/tests) suite for the `terraform-azuredevops-naming` module. It is inspired by the patterns established by the [Azure Verified Modules (AVM)](https://github.com/Azure/terraform-azurerm-avm-template) test layout.
+
+## Running locally
+
+```bash
+terraform init
+terraform test
+```
+
+`terraform test` will execute every `*.tftest.hcl` file in this directory. All tests run with `command = apply` against the `random` provider only — **no Azure DevOps credentials are required**.
+
+## Running a single file
+
+```bash
+terraform test -filter=tests/defaults.tftest.hcl
+```
+
+## Test catalogue
+
+| File | What it asserts |
+|---|---|
+| `defaults.tftest.hcl` | The module accepts zero arguments and produces non-empty outputs. |
+| `prefix_suffix.tftest.hcl` | `prefix` / `suffix` inputs flow into generated names with correct ordering. |
+| `environments.tftest.hcl` | Short environment tags are translated through `local.environment_mapping`. |
+| `branches.tftest.hcl` | Branch outputs honour the dash vs slash separator and lowercase enforcement. |
+| `validation.tftest.hcl` | Every `valid_name` and `valid_name_unique` flag in the validation map is `true` for representative inputs. |
+| `length_boundaries.tftest.hcl` | Names are correctly truncated to per-resource `max_length`. |
+| `regex_compliance.tftest.hcl` | All generated names match the per-resource regex captured from Microsoft naming-restrictions docs. |
+
+## Adding new tests
+
+When you add a new key to `local.azdo`:
+
+1. Extend `validation.tftest.hcl` with an assertion that its `valid_name` flag is `true`.
+2. If the key behaves differently for non-trivial inputs (e.g. takes a `for_each` input), add a focused `*.tftest.hcl` covering it.
+3. Run `terraform test` locally before pushing — CI will block the merge otherwise.
+
+## CI
+
+Tests run on every pull request via [`.github/workflows/test.yml`](../.github/workflows/test.yml). They are also triggered weekly by `scheduled_maintenance.yml`.

--- a/tests/branches.tftest.hcl
+++ b/tests/branches.tftest.hcl
@@ -1,0 +1,77 @@
+# Branch naming
+# Verifies the dash vs slash variants of work-item-driven branch names
+# (feature, bug, hotfix, release, etc.) and lowercase enforcement.
+
+variables {
+  prefix     = ["dbmh"]
+  suffix     = ["test"]
+  work_items = ["1234", "5678"]
+}
+
+run "feature_branch_dash_uses_hyphen_separator" {
+  command = apply
+
+  assert {
+    condition     = startswith(output.git_repository_feature_branch_dash["1234"].name, "feature-1234")
+    error_message = "Dash variant must use 'feature-<id>'; got: ${output.git_repository_feature_branch_dash["1234"].name}"
+  }
+}
+
+run "feature_branch_slash_uses_slash_separator" {
+  command = apply
+
+  assert {
+    condition     = startswith(output.git_repository_feature_branch_slash["1234"].name, "feature/1234")
+    error_message = "Slash variant must use 'feature/<id>'; got: ${output.git_repository_feature_branch_slash["1234"].name}"
+  }
+}
+
+run "all_branch_names_are_lowercased" {
+  command = apply
+
+  variables {
+    prefix     = ["DBMH"]
+    suffix     = ["TEST"]
+    work_items = ["9999"]
+  }
+
+  assert {
+    condition     = output.git_repository_feature_branch_dash["9999"].name == lower(output.git_repository_feature_branch_dash["9999"].name)
+    error_message = "Branch names must be lowercased even when prefix/suffix are uppercase"
+  }
+
+  assert {
+    condition     = output.git_repository_hotfix_branch_slash["9999"].name == lower(output.git_repository_hotfix_branch_slash["9999"].name)
+    error_message = "Hotfix slash branch names must be lowercased"
+  }
+}
+
+run "every_branch_variant_is_produced_per_work_item" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(output.git_repository_bug_branch_dash) == 2,
+      length(output.git_repository_dev_branch_dash) == 2,
+      length(output.git_repository_development_branch_dash) == 2,
+      length(output.git_repository_feature_branch_dash) == 2,
+      length(output.git_repository_fix_branch_dash) == 2,
+      length(output.git_repository_hotfix_branch_dash) == 2,
+      length(output.git_repository_release_branch_dash) == 2,
+    ])
+    error_message = "Every dash branch variant must produce one entry per work_item (expected 2 each)"
+  }
+
+  assert {
+    condition = alltrue([
+      length(output.git_repository_bug_branch_slash) == 2,
+      length(output.git_repository_dev_branch_slash) == 2,
+      length(output.git_repository_development_branch_slash) == 2,
+      length(output.git_repository_feature_branch_slash) == 2,
+      length(output.git_repository_fix_branch_slash) == 2,
+      length(output.git_repository_hotfix_branch_slash) == 2,
+      length(output.git_repository_release_branch_slash) == 2,
+    ])
+    error_message = "Every slash branch variant must produce one entry per work_item (expected 2 each)"
+  }
+}

--- a/tests/defaults.tftest.hcl
+++ b/tests/defaults.tftest.hcl
@@ -1,0 +1,66 @@
+# Defaults test
+# Verifies that the module can be instantiated with zero arguments and produces
+# the core set of outputs expected by every consumer. This is the smoke test —
+# if this fails, the module is broken at its most basic contract.
+
+run "module_loads_with_no_arguments" {
+  command = apply
+
+  assert {
+    condition     = output.project.name != null
+    error_message = "project.name must not be null when invoked with default inputs"
+  }
+
+  assert {
+    condition     = output.project.name_unique != null
+    error_message = "project.name_unique must not be null when invoked with default inputs"
+  }
+
+  assert {
+    condition     = output.project.slug == "prj"
+    error_message = "project.slug should default to 'prj'; got: ${output.project.slug}"
+  }
+
+  assert {
+    condition     = output.project.max_length == 64
+    error_message = "project.max_length should be 64 per MS naming-restrictions docs; got: ${output.project.max_length}"
+  }
+
+  assert {
+    condition     = length(output.project.name_unique) <= output.project.max_length
+    error_message = "project.name_unique exceeds max_length"
+  }
+}
+
+run "default_environment_tags_translated" {
+  command = apply
+
+  assert {
+    condition     = contains(keys(output.environment), "development")
+    error_message = "Default environment_tags include 'dev' which must translate to 'development'"
+  }
+
+  assert {
+    condition     = contains(keys(output.environment), "user-acceptance-testing")
+    error_message = "Default environment_tags include 'uat' which must translate to 'user-acceptance-testing'"
+  }
+
+  assert {
+    condition     = contains(keys(output.environment), "production")
+    error_message = "Default environment_tags include 'prd' which must translate to 'production'"
+  }
+}
+
+run "unique_suffix_default_length" {
+  command = apply
+
+  variables {
+    prefix = ["dbmh"]
+  }
+
+  assert {
+    # name_unique should be name + "-" + 4 random chars (default unique_length=4)
+    condition     = length(output.project.name_unique) == length(output.project.name) + 5
+    error_message = "Default unique_length=4 should add a 5-char tail (dash + 4 chars). Got name='${output.project.name}' name_unique='${output.project.name_unique}'"
+  }
+}

--- a/tests/environments.tftest.hcl
+++ b/tests/environments.tftest.hcl
@@ -1,0 +1,90 @@
+# Environment tag translation
+# Verifies the local.environment_mapping translation table behaves as documented.
+# Adding/removing tags here must be reflected in variables.tf validation.
+
+run "all_short_tags_translate_to_full_names" {
+  command = apply
+
+  variables {
+    environment_tags = ["acc", "aud", "com", "dev", "eph", "fet", "hot", "int", "pen", "per", "prd", "prod", "reg", "stg", "sys", "tst", "uat"]
+  }
+
+  assert {
+    condition     = contains(keys(output.environment), "accessibility-testing")
+    error_message = "'acc' must translate to 'accessibility-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "audit-testing")
+    error_message = "'aud' must translate to 'audit-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "compliance-testing")
+    error_message = "'com' must translate to 'compliance-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "development")
+    error_message = "'dev' must translate to 'development'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "ephemeral")
+    error_message = "'eph' must translate to 'ephemeral'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "feature")
+    error_message = "'fet' must translate to 'feature'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "hotfix")
+    error_message = "'hot' must translate to 'hotfix'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "integration-testing")
+    error_message = "'int' must translate to 'integration-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "penetration-testing")
+    error_message = "'pen' must translate to 'penetration-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "performance-testing")
+    error_message = "'per' must translate to 'performance-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "production")
+    error_message = "'prd' and 'prod' must translate to 'production'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "regression-testing")
+    error_message = "'reg' must translate to 'regression-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "staging")
+    error_message = "'stg' must translate to 'staging'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "system-testing")
+    error_message = "'sys' must translate to 'system-testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "testing")
+    error_message = "'tst' must translate to 'testing'"
+  }
+  assert {
+    condition     = contains(keys(output.environment), "user-acceptance-testing")
+    error_message = "'uat' must translate to 'user-acceptance-testing'"
+  }
+}
+
+run "duplicate_tags_collapse_to_single_environment" {
+  command = apply
+
+  variables {
+    # 'prd' and 'prod' both translate to 'production'
+    environment_tags = ["prd", "prod"]
+  }
+
+  assert {
+    condition     = length(keys(output.environment)) == 1
+    error_message = "'prd' and 'prod' both map to 'production' and should collapse to a single environment key; got ${length(keys(output.environment))}"
+  }
+}

--- a/tests/length_boundaries.tftest.hcl
+++ b/tests/length_boundaries.tftest.hcl
@@ -1,0 +1,53 @@
+# Length boundary testing
+# Verifies that very long inputs are correctly truncated to per-resource limits.
+# This protects consumers from accidentally generating names that would be
+# rejected at runtime by the Azure DevOps API.
+
+variables {
+  # 100 chars combined — guaranteed to overflow project (64) and git_repository (64)
+  prefix = ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+  suffix = ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"]
+}
+
+run "project_name_truncated_to_64" {
+  command = apply
+
+  assert {
+    condition     = length(output.project.name) == 64
+    error_message = "project.name must be truncated to exactly 64 chars; got length ${length(output.project.name)}"
+  }
+}
+
+run "git_repository_name_truncated_to_64" {
+  command = apply
+
+  assert {
+    condition     = length(output.git_repository.name) == 64
+    error_message = "git_repository.name must be truncated to exactly 64 chars; got length ${length(output.git_repository.name)}"
+  }
+}
+
+run "all_outputs_respect_their_max_length" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(output.project.name) <= output.project.max_length,
+      length(output.project.name_unique) <= output.project.max_length,
+      length(output.git_repository.name) <= output.git_repository.max_length,
+      length(output.git_repository.name_unique) <= output.git_repository.max_length,
+      length(output.git_repository_branch.name) <= output.git_repository_branch.max_length,
+      length(output.team.name) <= output.team.max_length,
+      length(output.variable_group.name) <= output.variable_group.max_length,
+      length(output.group.name) <= output.group.max_length,
+      length(output.agent_pool.name) <= output.agent_pool.max_length,
+      length(output.build_definition.name) <= output.build_definition.max_length,
+      length(output.build_folder.name) <= output.build_folder.max_length,
+      length(output.elastic_pool.name) <= output.elastic_pool.max_length,
+      length(output.serviceendpoint_azurerm.name) <= output.serviceendpoint_azurerm.max_length,
+      length(output.serviceendpoint_github.name) <= output.serviceendpoint_github.max_length,
+      length(output.serviceendpoint_kubernetes.name) <= output.serviceendpoint_kubernetes.max_length,
+    ])
+    error_message = "One or more outputs exceeded their declared max_length when given oversized inputs"
+  }
+}

--- a/tests/prefix_suffix.tftest.hcl
+++ b/tests/prefix_suffix.tftest.hcl
@@ -1,0 +1,50 @@
+# Prefix and suffix composition
+# Verifies that `prefix` and `suffix` inputs (both list(string)) are joined,
+# placed in the correct order, and that empty list elements are stripped.
+
+variables {
+  prefix = ["dbmh", "platform"]
+  suffix = ["uksouth", "001"]
+}
+
+run "prefix_suffix_appear_in_project_name" {
+  command = apply
+
+  assert {
+    condition     = startswith(output.project.name, "dbmh-platform-")
+    error_message = "project.name must start with 'dbmh-platform-'; got: ${output.project.name}"
+  }
+
+  assert {
+    condition     = endswith(output.project.name, "-uksouth-001")
+    error_message = "project.name must end with '-uksouth-001'; got: ${output.project.name}"
+  }
+}
+
+run "git_repository_name_is_lowercased" {
+  command = apply
+
+  variables {
+    prefix = ["DBMH", "Platform"]
+    suffix = ["UKSouth", "001"]
+  }
+
+  assert {
+    condition     = output.git_repository.name == lower(output.git_repository.name)
+    error_message = "git_repository.name must be lowercased; got: ${output.git_repository.name}"
+  }
+}
+
+run "empty_prefix_does_not_introduce_leading_separator" {
+  command = apply
+
+  variables {
+    prefix = []
+    suffix = ["uksouth"]
+  }
+
+  assert {
+    condition     = !startswith(output.project.name, "-")
+    error_message = "project.name must not start with a separator when prefix is empty; got: ${output.project.name}"
+  }
+}

--- a/tests/regex_compliance.tftest.hcl
+++ b/tests/regex_compliance.tftest.hcl
@@ -1,0 +1,93 @@
+# Regex compliance
+# Walks every top-level (non-collection) output and asserts that the generated
+# name matches its declared regex. Iterating outputs at runtime isn't possible
+# in terraform test, so this enumerates the keys explicitly. Add new entries
+# here whenever a new key is added to local.azdo.
+
+variables {
+  prefix = ["dbmh"]
+  suffix = ["v11"]
+}
+
+run "every_simple_output_matches_its_regex" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(regexall(output.agent_pool.regex, output.agent_pool.name)) > 0,
+      length(regexall(output.branch_policy_build_validation.regex, output.branch_policy_build_validation.name)) > 0,
+      length(regexall(output.build_definition.regex, output.build_definition.name)) > 0,
+      length(regexall(output.build_folder.regex, output.build_folder.name)) > 0,
+      length(regexall(output.elastic_pool.regex, output.elastic_pool.name)) > 0,
+      length(regexall(output.git_repository.regex, output.git_repository.name)) > 0,
+      length(regexall(output.git_repository_branch.regex, output.git_repository_branch.name)) > 0,
+      length(regexall(output.group.regex, output.group.name)) > 0,
+      length(regexall(output.project.regex, output.project.name)) > 0,
+      length(regexall(output.team.regex, output.team.name)) > 0,
+      length(regexall(output.variable_group.regex, output.variable_group.name)) > 0,
+    ])
+    error_message = "One or more core outputs failed regex compliance — inspect outputs vs their declared regex"
+  }
+}
+
+run "every_simple_output_matches_its_regex_unique" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(regexall(output.agent_pool.regex, output.agent_pool.name_unique)) > 0,
+      length(regexall(output.branch_policy_build_validation.regex, output.branch_policy_build_validation.name_unique)) > 0,
+      length(regexall(output.build_definition.regex, output.build_definition.name_unique)) > 0,
+      length(regexall(output.build_folder.regex, output.build_folder.name_unique)) > 0,
+      length(regexall(output.elastic_pool.regex, output.elastic_pool.name_unique)) > 0,
+      length(regexall(output.git_repository.regex, output.git_repository.name_unique)) > 0,
+      length(regexall(output.git_repository_branch.regex, output.git_repository_branch.name_unique)) > 0,
+      length(regexall(output.group.regex, output.group.name_unique)) > 0,
+      length(regexall(output.project.regex, output.project.name_unique)) > 0,
+      length(regexall(output.team.regex, output.team.name_unique)) > 0,
+      length(regexall(output.variable_group.regex, output.variable_group.name_unique)) > 0,
+    ])
+    error_message = "One or more core outputs failed regex compliance for name_unique"
+  }
+}
+
+run "every_serviceendpoint_matches_its_regex" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      length(regexall(output.serviceendpoint_argocd.regex, output.serviceendpoint_argocd.name)) > 0,
+      length(regexall(output.serviceendpoint_artifactory.regex, output.serviceendpoint_artifactory.name)) > 0,
+      length(regexall(output.serviceendpoint_aws.regex, output.serviceendpoint_aws.name)) > 0,
+      length(regexall(output.serviceendpoint_azurecr.regex, output.serviceendpoint_azurecr.name)) > 0,
+      length(regexall(output.serviceendpoint_azuredevops.regex, output.serviceendpoint_azuredevops.name)) > 0,
+      length(regexall(output.serviceendpoint_azurerm.regex, output.serviceendpoint_azurerm.name)) > 0,
+      length(regexall(output.serviceendpoint_bitbucket.regex, output.serviceendpoint_bitbucket.name)) > 0,
+      length(regexall(output.serviceendpoint_dockerregistry.regex, output.serviceendpoint_dockerregistry.name)) > 0,
+      length(regexall(output.serviceendpoint_externaltfs.regex, output.serviceendpoint_externaltfs.name)) > 0,
+      length(regexall(output.serviceendpoint_gcp_terraform.regex, output.serviceendpoint_gcp_terraform.name)) > 0,
+      length(regexall(output.serviceendpoint_generic.regex, output.serviceendpoint_generic.name)) > 0,
+      length(regexall(output.serviceendpoint_generic_git.regex, output.serviceendpoint_generic_git.name)) > 0,
+      length(regexall(output.serviceendpoint_github.regex, output.serviceendpoint_github.name)) > 0,
+      length(regexall(output.serviceendpoint_github_enterprise.regex, output.serviceendpoint_github_enterprise.name)) > 0,
+      length(regexall(output.serviceendpoint_incomingwebhook.regex, output.serviceendpoint_incomingwebhook.name)) > 0,
+      length(regexall(output.serviceendpoint_jenkins.regex, output.serviceendpoint_jenkins.name)) > 0,
+      length(regexall(output.serviceendpoint_jfrog_artifactory_v2.regex, output.serviceendpoint_jfrog_artifactory_v2.name)) > 0,
+      length(regexall(output.serviceendpoint_jfrog_distribution_v2.regex, output.serviceendpoint_jfrog_distribution_v2.name)) > 0,
+      length(regexall(output.serviceendpoint_jfrog_platform_v2.regex, output.serviceendpoint_jfrog_platform_v2.name)) > 0,
+      length(regexall(output.serviceendpoint_jfrog_xray_v2.regex, output.serviceendpoint_jfrog_xray_v2.name)) > 0,
+      length(regexall(output.serviceendpoint_kubernetes.regex, output.serviceendpoint_kubernetes.name)) > 0,
+      length(regexall(output.serviceendpoint_maven.regex, output.serviceendpoint_maven.name)) > 0,
+      length(regexall(output.serviceendpoint_nexus.regex, output.serviceendpoint_nexus.name)) > 0,
+      length(regexall(output.serviceendpoint_npm.regex, output.serviceendpoint_npm.name)) > 0,
+      length(regexall(output.serviceendpoint_nuget.regex, output.serviceendpoint_nuget.name)) > 0,
+      length(regexall(output.serviceendpoint_octopusdeploy.regex, output.serviceendpoint_octopusdeploy.name)) > 0,
+      length(regexall(output.serviceendpoint_runpipeline.regex, output.serviceendpoint_runpipeline.name)) > 0,
+      length(regexall(output.serviceendpoint_servicefabric.regex, output.serviceendpoint_servicefabric.name)) > 0,
+      length(regexall(output.serviceendpoint_sonarcloud.regex, output.serviceendpoint_sonarcloud.name)) > 0,
+      length(regexall(output.serviceendpoint_sonarqube.regex, output.serviceendpoint_sonarqube.name)) > 0,
+      length(regexall(output.serviceendpoint_ssh.regex, output.serviceendpoint_ssh.name)) > 0,
+    ])
+    error_message = "One or more service endpoint outputs failed regex compliance"
+  }
+}

--- a/tests/validation.tftest.hcl
+++ b/tests/validation.tftest.hcl
@@ -1,0 +1,99 @@
+# Validation flags
+# Verifies that, for representative inputs, every name produced by the module
+# satisfies its declared regex and length constraints. The module exposes a
+# parallel `validation` map but does not expose it as an output today; we rely
+# on the per-resource scope by checking representative outputs against their
+# own regex/min_length/max_length.
+
+variables {
+  prefix     = ["dbmh"]
+  suffix     = ["v11"]
+  work_items = ["1234"]
+}
+
+run "core_outputs_match_their_regex" {
+  command = apply
+
+  assert {
+    condition     = length(regexall(output.project.regex, output.project.name)) > 0
+    error_message = "project.name '${output.project.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.git_repository.regex, output.git_repository.name)) > 0
+    error_message = "git_repository.name '${output.git_repository.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.team.regex, output.team.name)) > 0
+    error_message = "team.name '${output.team.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.variable_group.regex, output.variable_group.name)) > 0
+    error_message = "variable_group.name '${output.variable_group.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.group.regex, output.group.name)) > 0
+    error_message = "group.name '${output.group.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.agent_pool.regex, output.agent_pool.name)) > 0
+    error_message = "agent_pool.name '${output.agent_pool.name}' must match its declared regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.build_definition.regex, output.build_definition.name)) > 0
+    error_message = "build_definition.name '${output.build_definition.name}' must match its declared regex"
+  }
+}
+
+run "core_outputs_respect_max_length" {
+  command = apply
+
+  assert {
+    condition     = length(output.project.name) <= output.project.max_length
+    error_message = "project.name length ${length(output.project.name)} exceeds max_length ${output.project.max_length}"
+  }
+
+  assert {
+    condition     = length(output.project.name_unique) <= output.project.max_length
+    error_message = "project.name_unique length ${length(output.project.name_unique)} exceeds max_length ${output.project.max_length}"
+  }
+
+  assert {
+    condition     = length(output.git_repository.name) <= output.git_repository.max_length
+    error_message = "git_repository.name exceeds max_length"
+  }
+
+  assert {
+    condition     = length(output.team.name) <= output.team.max_length
+    error_message = "team.name exceeds max_length"
+  }
+
+  assert {
+    condition     = length(output.variable_group.name) <= output.variable_group.max_length
+    error_message = "variable_group.name exceeds max_length"
+  }
+}
+
+run "service_endpoints_match_their_regex" {
+  command = apply
+
+  assert {
+    condition     = length(regexall(output.serviceendpoint_azurerm.regex, output.serviceendpoint_azurerm.name)) > 0
+    error_message = "serviceendpoint_azurerm.name must match its regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.serviceendpoint_github.regex, output.serviceendpoint_github.name)) > 0
+    error_message = "serviceendpoint_github.name must match its regex"
+  }
+
+  assert {
+    condition     = length(regexall(output.serviceendpoint_kubernetes.regex, output.serviceendpoint_kubernetes.name)) > 0
+    error_message = "serviceendpoint_kubernetes.name must match its regex"
+  }
+}


### PR DESCRIPTION
## Checkpoint 1 / 11 — `release/v11`

First slice of the **v11.0.0 overhaul**. Lays down a regression-proof testing foundation **before** any functional work begins so that every subsequent checkpoint can be reviewed against a passing test suite.

> Module is consumed by **196 000+** downstream users — every PR into `release/v11` ships with a green `terraform test` run.

---

### What's in this PR

#### 🧪 Native `terraform test` suite — `tests/`
| File | Runs | Focus |
| --- | --- | --- |
| `defaults.tftest.hcl` | 3 | module loads with no args, default env tags translated, default unique-suffix length |
| `prefix_suffix.tftest.hcl` | 3 | prefix/suffix appear in generated names, lowercase enforcement on git repo, no leading separator with empty prefix |
| `environments.tftest.hcl` | 2 | all 17 short codes translate, duplicate short codes collapse to a single environment |
| `branches.tftest.hcl` | 4 | dash vs slash separators, lowercase enforcement, every branch variant produces 1 entry per work_item |
| `validation.tftest.hcl` | 3 | core outputs match their MS-doc regex, respect `max_length`, three representative service endpoints |
| `length_boundaries.tftest.hcl` | 3 | 100-char prefix+suffix → output length capped at `max_length` for project, repo and 15 enumerated outputs |
| `regex_compliance.tftest.hcl` | 3 | full sweep of every simple output (`name` + `name_unique`) and all 31 `serviceendpoint_*` outputs against their regex |

**Result:** `Success! 21 passed, 0 failed.`

#### 🛠️ CI — `.github/workflows/test.yml`
- Runs `terraform fmt -check`, `validate` and `test -verbose` on every PR/push touching `**.tf` or `tests/`
- Matrix: Terraform `1.14.0` (the `required_version` floor) and `latest`
- No cloud creds needed — only the `random` provider is used

#### 🪝 Pre-commit — `terraform_test` hook
Added under the existing `antonbabenko/pre-commit-terraform` block so contributors catch regressions locally before pushing.

#### 🐛 Bug fix surfaced by the new tests
`local.translated_environment_tags` previously crashed with `Duplicate object key` whenever a consumer passed two short codes that mapped to the same long name (e.g. `prd` + `prod` → `production`). Wrapped in `distinct()` — fully backward-compatible for every consumer that wasn't already crashing.

---

### v11 roadmap (for context only — not in this PR)

| # | Checkpoint | Status |
| --- | --- | --- |
| **1** | **Test scaffold + CI + pre-commit hook** | **← this PR** |
| 2 | Add ~15 new `serviceendpoint_*` resource types from MS docs | next |
| 3 | Add missing AzureRM provider resources (agent_queue, dashboard, deployment_group, feed, wiki, wiki_page, workitem*, etc.) | |
| 4 | Add MS-doc-only concepts (area_path, iteration_path, board_column, pipeline_stage, organization, process, security_group, …) | |
| 5 | Mirror checkpoints 2–4 into `validation.tf` and `outputs.tf` | |
| 6 | Add optional inputs in `variables.tf` for new collections (default `[]`) | |
| 7 | README modernisation — `<picture>` dark-mode logo, badges, TOC, "What's new in v11" | |
| 8 | `MIGRATION.md` (v10 → v11) + `CHANGELOG.md` v11.0.0 | |
| 9 | Bump `examples/` version constraints to `>= 11.0.0, < 12.0.0`; add `example3` for new resources | |
| 10 | Final dependency version bumps | |
| 11 | Final `terraform fmt` + `validate` + `test` and the `release/v11` → `main` PR for v11.0.0 | |

### Backward-compatibility guarantees
- ✅ No existing output keys removed
- ✅ No existing variable defaults changed
- ✅ Bug fix is a strict superset of previous behaviour
- ✅ All 21 tests green on Terraform 1.14.0 and latest

### How to run locally
```bash
terraform init -backend=false
terraform test
```
