### PR TITLE
feat(serviceendpoints): ✨ add 11 new service endpoint types for v11

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -793,6 +793,127 @@ locals {
       regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
     }
 
+    serviceendpoint_azure_service_bus = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "seasb"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_black_duck = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "sebd"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_checkmarx_one = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "secm1"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_checkmarx_sast = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "secmst"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_checkmarx_sca = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "secmsca"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_dynamics_lifecycle_services = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "sedls"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_generic_v2 = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "seg2"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_gitlab = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "segl"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_openshift = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "seos"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_snyk = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "sesnyk"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    serviceendpoint_visualstudiomarketplace = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 1024))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 1024))
+      dashes      = true
+      slug        = "sevsm"
+      min_length  = 1
+      max_length  = 1024
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
 
     team = {
       name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 255))

--- a/outputs.tf
+++ b/outputs.tf
@@ -370,6 +370,72 @@ output "serviceendpoint_ssh" {
   value       = local.azdo.serviceendpoint_ssh
 }
 
+output "serviceendpoint_azure_service_bus" {
+  description = "The Azure Service Bus service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_azure_service_bus
+}
+
+output "serviceendpoint_black_duck" {
+  description = "The Black Duck service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_black_duck
+}
+
+output "serviceendpoint_checkmarx_one" {
+  description = "The Checkmarx One service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_checkmarx_one
+}
+
+output "serviceendpoint_checkmarx_sast" {
+  description = "The Checkmarx SAST service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_checkmarx_sast
+}
+
+output "serviceendpoint_checkmarx_sca" {
+  description = "The Checkmarx SCA service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_checkmarx_sca
+}
+
+output "serviceendpoint_dynamics_lifecycle_services" {
+  description = "The Dynamics Lifecycle Services service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_dynamics_lifecycle_services
+}
+
+output "serviceendpoint_generic_v2" {
+  description = "The Generic v2 service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_generic_v2
+}
+
+output "serviceendpoint_gitlab" {
+  description = "The GitLab service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_gitlab
+}
+
+output "serviceendpoint_openshift" {
+  description = "The OpenShift service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_openshift
+}
+
+output "serviceendpoint_snyk" {
+  description = "The Snyk service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_snyk
+}
+
+output "serviceendpoint_visualstudiomarketplace" {
+  description = "The Visual Studio Marketplace service endpoint in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.serviceendpoint_visualstudiomarketplace
+}
+
 output "team" {
   description = "The team in Azure DevOps"
   sensitive   = false

--- a/validation.tf
+++ b/validation.tf
@@ -332,6 +332,61 @@ locals {
       valid_name_unique = length(regexall(local.azdo.serviceendpoint_ssh.regex, local.azdo.serviceendpoint_ssh.name_unique)) > 0
     }
 
+    serviceendpoint_azure_service_bus = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_azure_service_bus.regex, local.azdo.serviceendpoint_azure_service_bus.name)) > 0 && length(local.azdo.serviceendpoint_azure_service_bus.name) > local.azdo.serviceendpoint_azure_service_bus.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_azure_service_bus.regex, local.azdo.serviceendpoint_azure_service_bus.name_unique)) > 0
+    }
+
+    serviceendpoint_black_duck = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_black_duck.regex, local.azdo.serviceendpoint_black_duck.name)) > 0 && length(local.azdo.serviceendpoint_black_duck.name) > local.azdo.serviceendpoint_black_duck.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_black_duck.regex, local.azdo.serviceendpoint_black_duck.name_unique)) > 0
+    }
+
+    serviceendpoint_checkmarx_one = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_checkmarx_one.regex, local.azdo.serviceendpoint_checkmarx_one.name)) > 0 && length(local.azdo.serviceendpoint_checkmarx_one.name) > local.azdo.serviceendpoint_checkmarx_one.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_checkmarx_one.regex, local.azdo.serviceendpoint_checkmarx_one.name_unique)) > 0
+    }
+
+    serviceendpoint_checkmarx_sast = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_checkmarx_sast.regex, local.azdo.serviceendpoint_checkmarx_sast.name)) > 0 && length(local.azdo.serviceendpoint_checkmarx_sast.name) > local.azdo.serviceendpoint_checkmarx_sast.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_checkmarx_sast.regex, local.azdo.serviceendpoint_checkmarx_sast.name_unique)) > 0
+    }
+
+    serviceendpoint_checkmarx_sca = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_checkmarx_sca.regex, local.azdo.serviceendpoint_checkmarx_sca.name)) > 0 && length(local.azdo.serviceendpoint_checkmarx_sca.name) > local.azdo.serviceendpoint_checkmarx_sca.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_checkmarx_sca.regex, local.azdo.serviceendpoint_checkmarx_sca.name_unique)) > 0
+    }
+
+    serviceendpoint_dynamics_lifecycle_services = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_dynamics_lifecycle_services.regex, local.azdo.serviceendpoint_dynamics_lifecycle_services.name)) > 0 && length(local.azdo.serviceendpoint_dynamics_lifecycle_services.name) > local.azdo.serviceendpoint_dynamics_lifecycle_services.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_dynamics_lifecycle_services.regex, local.azdo.serviceendpoint_dynamics_lifecycle_services.name_unique)) > 0
+    }
+
+    serviceendpoint_generic_v2 = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_generic_v2.regex, local.azdo.serviceendpoint_generic_v2.name)) > 0 && length(local.azdo.serviceendpoint_generic_v2.name) > local.azdo.serviceendpoint_generic_v2.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_generic_v2.regex, local.azdo.serviceendpoint_generic_v2.name_unique)) > 0
+    }
+
+    serviceendpoint_gitlab = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_gitlab.regex, local.azdo.serviceendpoint_gitlab.name)) > 0 && length(local.azdo.serviceendpoint_gitlab.name) > local.azdo.serviceendpoint_gitlab.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_gitlab.regex, local.azdo.serviceendpoint_gitlab.name_unique)) > 0
+    }
+
+    serviceendpoint_openshift = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_openshift.regex, local.azdo.serviceendpoint_openshift.name)) > 0 && length(local.azdo.serviceendpoint_openshift.name) > local.azdo.serviceendpoint_openshift.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_openshift.regex, local.azdo.serviceendpoint_openshift.name_unique)) > 0
+    }
+
+    serviceendpoint_snyk = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_snyk.regex, local.azdo.serviceendpoint_snyk.name)) > 0 && length(local.azdo.serviceendpoint_snyk.name) > local.azdo.serviceendpoint_snyk.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_snyk.regex, local.azdo.serviceendpoint_snyk.name_unique)) > 0
+    }
+
+    serviceendpoint_visualstudiomarketplace = {
+      valid_name        = length(regexall(local.azdo.serviceendpoint_visualstudiomarketplace.regex, local.azdo.serviceendpoint_visualstudiomarketplace.name)) > 0 && length(local.azdo.serviceendpoint_visualstudiomarketplace.name) > local.azdo.serviceendpoint_visualstudiomarketplace.min_length
+      valid_name_unique = length(regexall(local.azdo.serviceendpoint_visualstudiomarketplace.regex, local.azdo.serviceendpoint_visualstudiomarketplace.name_unique)) > 0
+    }
+
 
     team = {
       valid_name        = length(regexall(local.azdo.team.regex, local.azdo.team.name)) > 0 && length(local.azdo.team.name) > local.azdo.team.min_length


### PR DESCRIPTION
Adds 11 new `serviceendpoint_*` resource types to `local.azdo`, mirrored in `validation.tf` and `outputs.tf`:

- `serviceendpoint_azure_service_bus` (seasb)
- `serviceendpoint_black_duck` (sebd)
- `serviceendpoint_checkmarx_one` (secm1)
- `serviceendpoint_checkmarx_sast` (secmst)
- `serviceendpoint_checkmarx_sca` (secmsca)
- `serviceendpoint_dynamics_lifecycle_services` (sedls)
- `serviceendpoint_generic_v2` (seg2)
- `serviceendpoint_gitlab` (segl)
- `serviceendpoint_openshift` (seos)
- `serviceendpoint_snyk` (sesnyk)
- `serviceendpoint_visualstudiomarketplace` (sevsm)

Aligns with microsoft/azuredevops provider 1.15.1 surface for v11. Additive only — no breaking changes for the 196k+ existing consumers.

`terraform validate` passes. Tests will follow once PR #241 (tests scaffold) is merged into `release/v11`.

Part of v11 overhaul (Checkpoint 2).