### PR TITLE
✨ feat(azdo): add 18 new resource naming definitions for v11

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -815,6 +815,204 @@ locals {
       scope       = "Project"
       regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
     }
+
+    agent_queue = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 64)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 64)
+      dashes      = true
+      slug        = "aq"
+      min_length  = 1
+      max_length  = 64
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    dashboard = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "dash"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    deployment_group = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "dg"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    environment_kubernetes_resource = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "ekr"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    feed = {
+      name        = lower(substr(join("-", compact([local.prefix, "", local.suffix])), 0, 64))
+      name_unique = lower(substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 64))
+      dashes      = true
+      slug        = "feed"
+      min_length  = 1
+      max_length  = 64
+      scope       = "Project"
+      regex       = "^[A-Za-z0-9_.\\-]+$"
+    }
+
+    variable_group_variable = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "vgv"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    wiki = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 235)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 235)
+      dashes      = true
+      slug        = "wiki"
+      min_length  = 1
+      max_length  = 235
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    wiki_page = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 235)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 235)
+      dashes      = true
+      slug        = "wp"
+      min_length  = 1
+      max_length  = 235
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitem = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 255)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 255)
+      dashes      = true
+      slug        = "wi"
+      min_length  = 1
+      max_length  = 255
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemquery = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 255)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 255)
+      dashes      = true
+      slug        = "wiq"
+      min_length  = 1
+      max_length  = 255
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemquery_folder = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 255)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 255)
+      dashes      = true
+      slug        = "wiqf"
+      min_length  = 1
+      max_length  = 255
+      scope       = "Project"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtracking_field = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 128)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 128)
+      dashes      = true
+      slug        = "wtfld"
+      min_length  = 1
+      max_length  = 128
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_process = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtpp"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_field = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtpfld"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_group = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtpg"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_page = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtppg"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_state = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtps"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
+
+    workitemtrackingprocess_workitemtype = {
+      name        = substr(join("-", compact([local.prefix, "", local.suffix])), 0, 256)
+      name_unique = substr(join("-", compact([local.prefix, "", local.suffix_unique])), 0, 256)
+      dashes      = true
+      slug        = "wtpwit"
+      min_length  = 1
+      max_length  = 256
+      scope       = "Organization"
+      regex       = "^[^/\\:*?\"<>|~';.,\\[\\]{}()@#$%^&!+=]*$"
+    }
   }
 
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -393,3 +393,112 @@ output "validation" {
   sensitive   = false
   value       = local.validation
 }
+
+output "agent_queue" {
+  description = "The Agent queue in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.agent_queue
+}
+
+output "dashboard" {
+  description = "The Dashboard in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.dashboard
+}
+
+output "deployment_group" {
+  description = "The Deployment group in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.deployment_group
+}
+
+output "environment_kubernetes_resource" {
+  description = "The Environment Kubernetes resource in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.environment_kubernetes_resource
+}
+
+output "feed" {
+  description = "The Artifact feed in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.feed
+}
+
+output "variable_group_variable" {
+  description = "The Variable group variable in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.variable_group_variable
+}
+
+output "wiki" {
+  description = "The Wiki in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.wiki
+}
+
+output "wiki_page" {
+  description = "The Wiki page in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.wiki_page
+}
+
+output "workitem" {
+  description = "The Work item in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitem
+}
+
+output "workitemquery" {
+  description = "The Work item query in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemquery
+}
+
+output "workitemquery_folder" {
+  description = "The Work item query folder in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemquery_folder
+}
+
+output "workitemtracking_field" {
+  description = "The Work item tracking field in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtracking_field
+}
+
+output "workitemtrackingprocess_process" {
+  description = "The Work item tracking process in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_process
+}
+
+output "workitemtrackingprocess_field" {
+  description = "The Work item tracking process field in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_field
+}
+
+output "workitemtrackingprocess_group" {
+  description = "The Work item tracking process group in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_group
+}
+
+output "workitemtrackingprocess_page" {
+  description = "The Work item tracking process page in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_page
+}
+
+output "workitemtrackingprocess_state" {
+  description = "The Work item tracking process state in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_state
+}
+
+output "workitemtrackingprocess_workitemtype" {
+  description = "The Work item tracking process work item type in Azure DevOps"
+  sensitive   = false
+  value       = local.azdo.workitemtrackingprocess_workitemtype
+}
+

--- a/validation.tf
+++ b/validation.tf
@@ -343,5 +343,95 @@ locals {
       valid_name_unique = length(regexall(local.azdo.variable_group.regex, local.azdo.variable_group.name_unique)) > 0
     }
 
+    agent_queue = {
+      valid_name        = length(regexall(local.azdo.agent_queue.regex, local.azdo.agent_queue.name)) > 0 && length(local.azdo.agent_queue.name) > local.azdo.agent_queue.min_length
+      valid_name_unique = length(regexall(local.azdo.agent_queue.regex, local.azdo.agent_queue.name_unique)) > 0
+    }
+
+    dashboard = {
+      valid_name        = length(regexall(local.azdo.dashboard.regex, local.azdo.dashboard.name)) > 0 && length(local.azdo.dashboard.name) > local.azdo.dashboard.min_length
+      valid_name_unique = length(regexall(local.azdo.dashboard.regex, local.azdo.dashboard.name_unique)) > 0
+    }
+
+    deployment_group = {
+      valid_name        = length(regexall(local.azdo.deployment_group.regex, local.azdo.deployment_group.name)) > 0 && length(local.azdo.deployment_group.name) > local.azdo.deployment_group.min_length
+      valid_name_unique = length(regexall(local.azdo.deployment_group.regex, local.azdo.deployment_group.name_unique)) > 0
+    }
+
+    environment_kubernetes_resource = {
+      valid_name        = length(regexall(local.azdo.environment_kubernetes_resource.regex, local.azdo.environment_kubernetes_resource.name)) > 0 && length(local.azdo.environment_kubernetes_resource.name) > local.azdo.environment_kubernetes_resource.min_length
+      valid_name_unique = length(regexall(local.azdo.environment_kubernetes_resource.regex, local.azdo.environment_kubernetes_resource.name_unique)) > 0
+    }
+
+    feed = {
+      valid_name        = length(regexall(local.azdo.feed.regex, local.azdo.feed.name)) > 0 && length(local.azdo.feed.name) > local.azdo.feed.min_length
+      valid_name_unique = length(regexall(local.azdo.feed.regex, local.azdo.feed.name_unique)) > 0
+    }
+
+    variable_group_variable = {
+      valid_name        = length(regexall(local.azdo.variable_group_variable.regex, local.azdo.variable_group_variable.name)) > 0 && length(local.azdo.variable_group_variable.name) > local.azdo.variable_group_variable.min_length
+      valid_name_unique = length(regexall(local.azdo.variable_group_variable.regex, local.azdo.variable_group_variable.name_unique)) > 0
+    }
+
+    wiki = {
+      valid_name        = length(regexall(local.azdo.wiki.regex, local.azdo.wiki.name)) > 0 && length(local.azdo.wiki.name) > local.azdo.wiki.min_length
+      valid_name_unique = length(regexall(local.azdo.wiki.regex, local.azdo.wiki.name_unique)) > 0
+    }
+
+    wiki_page = {
+      valid_name        = length(regexall(local.azdo.wiki_page.regex, local.azdo.wiki_page.name)) > 0 && length(local.azdo.wiki_page.name) > local.azdo.wiki_page.min_length
+      valid_name_unique = length(regexall(local.azdo.wiki_page.regex, local.azdo.wiki_page.name_unique)) > 0
+    }
+
+    workitem = {
+      valid_name        = length(regexall(local.azdo.workitem.regex, local.azdo.workitem.name)) > 0 && length(local.azdo.workitem.name) > local.azdo.workitem.min_length
+      valid_name_unique = length(regexall(local.azdo.workitem.regex, local.azdo.workitem.name_unique)) > 0
+    }
+
+    workitemquery = {
+      valid_name        = length(regexall(local.azdo.workitemquery.regex, local.azdo.workitemquery.name)) > 0 && length(local.azdo.workitemquery.name) > local.azdo.workitemquery.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemquery.regex, local.azdo.workitemquery.name_unique)) > 0
+    }
+
+    workitemquery_folder = {
+      valid_name        = length(regexall(local.azdo.workitemquery_folder.regex, local.azdo.workitemquery_folder.name)) > 0 && length(local.azdo.workitemquery_folder.name) > local.azdo.workitemquery_folder.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemquery_folder.regex, local.azdo.workitemquery_folder.name_unique)) > 0
+    }
+
+    workitemtracking_field = {
+      valid_name        = length(regexall(local.azdo.workitemtracking_field.regex, local.azdo.workitemtracking_field.name)) > 0 && length(local.azdo.workitemtracking_field.name) > local.azdo.workitemtracking_field.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtracking_field.regex, local.azdo.workitemtracking_field.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_process = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_process.regex, local.azdo.workitemtrackingprocess_process.name)) > 0 && length(local.azdo.workitemtrackingprocess_process.name) > local.azdo.workitemtrackingprocess_process.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_process.regex, local.azdo.workitemtrackingprocess_process.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_field = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_field.regex, local.azdo.workitemtrackingprocess_field.name)) > 0 && length(local.azdo.workitemtrackingprocess_field.name) > local.azdo.workitemtrackingprocess_field.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_field.regex, local.azdo.workitemtrackingprocess_field.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_group = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_group.regex, local.azdo.workitemtrackingprocess_group.name)) > 0 && length(local.azdo.workitemtrackingprocess_group.name) > local.azdo.workitemtrackingprocess_group.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_group.regex, local.azdo.workitemtrackingprocess_group.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_page = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_page.regex, local.azdo.workitemtrackingprocess_page.name)) > 0 && length(local.azdo.workitemtrackingprocess_page.name) > local.azdo.workitemtrackingprocess_page.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_page.regex, local.azdo.workitemtrackingprocess_page.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_state = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_state.regex, local.azdo.workitemtrackingprocess_state.name)) > 0 && length(local.azdo.workitemtrackingprocess_state.name) > local.azdo.workitemtrackingprocess_state.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_state.regex, local.azdo.workitemtrackingprocess_state.name_unique)) > 0
+    }
+
+    workitemtrackingprocess_workitemtype = {
+      valid_name        = length(regexall(local.azdo.workitemtrackingprocess_workitemtype.regex, local.azdo.workitemtrackingprocess_workitemtype.name)) > 0 && length(local.azdo.workitemtrackingprocess_workitemtype.name) > local.azdo.workitemtrackingprocess_workitemtype.min_length
+      valid_name_unique = length(regexall(local.azdo.workitemtrackingprocess_workitemtype.regex, local.azdo.workitemtrackingprocess_workitemtype.name_unique)) > 0
+    }
+
   }
 }


### PR DESCRIPTION
## Summary

Adds standardized naming for 18 previously-uncovered Azure DevOps resources.

### Project-scope resources (provider-backed)
- `agent_queue` (slug: aq, max 64)
- `dashboard` (dash, 256)
- `deployment_group` (dg, 256)
- `environment_kubernetes_resource` (ekr, 256)
- `feed` (feed, 64, lowercased)
- `variable_group_variable` (vgv, 256)
- `wiki` (wiki, 235), `wiki_page` (wp, 235)
- `workitem` (wi, 255), `workitemquery` (wiq, 255), `workitemquery_folder` (wiqf, 255)

### Organization-scope work item tracking resources
- `workitemtracking_field` (wtfld, 128)
- `workitemtrackingprocess_process` (wtpp, 256)
- `workitemtrackingprocess_field` (wtpfld, 256)
- `workitemtrackingprocess_group` (wtpg, 256)
- `workitemtrackingprocess_page` (wtppg, 256)
- `workitemtrackingprocess_state` (wtps, 256)
- `workitemtrackingprocess_workitemtype` (wtpwit, 256)

## Schema
Each entry follows the standard pattern with `name`, `name_unique`, `dashes`, `slug`, `min_length`, `max_length`, `scope`, and `regex`. Mirrored 1:1 in `main.tf`, `validation.tf`, and `outputs.tf`.

## Validation
- ✅ `terraform fmt -recursive`
- ✅ `terraform validate`

## Backwards compatibility
Strictly additive — no breaking changes for existing consumers.

Part of the v11 overhaul (Checkpoint 3).