### PR TITLE
✨ feat(vars): add 8 optional input lists for v11 conceptual resources

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,51 @@ variable "work_items" {
   description = "List of Work Items or issue numbers to be used in branch name and environment name creation. For example, ['1234', '1235'] will create branch names like 'feature/1234-' and 'feature/1235-'."
   default     = []
 }
+
+variable "area_paths" {
+  type        = list(string)
+  description = "Optional list of area path names to generate naming for. Used by the area_path resource."
+  default     = []
+}
+
+variable "iteration_paths" {
+  type        = list(string)
+  description = "Optional list of iteration path names to generate naming for. Used by the iteration_path resource."
+  default     = []
+}
+
+variable "dashboards" {
+  type        = list(string)
+  description = "Optional list of dashboard names to generate naming for. Used by the dashboard resource."
+  default     = []
+}
+
+variable "feeds" {
+  type        = list(string)
+  description = "Optional list of artifact feed names to generate naming for. Used by the feed resource."
+  default     = []
+}
+
+variable "wiki_pages" {
+  type        = list(string)
+  description = "Optional list of wiki page names to generate naming for. Used by the wiki_page resource."
+  default     = []
+}
+
+variable "pipeline_stages" {
+  type        = list(string)
+  description = "Optional list of pipeline stage names to generate naming for. Used by the pipeline_stage resource."
+  default     = []
+}
+
+variable "pipeline_jobs" {
+  type        = list(string)
+  description = "Optional list of pipeline job names to generate naming for. Used by the pipeline_job resource."
+  default     = []
+}
+
+variable "pipeline_variables" {
+  type        = list(string)
+  description = "Optional list of pipeline variable names to generate naming for. Used by the pipeline_variable resource."
+  default     = []
+}


### PR DESCRIPTION
## Summary

Adds 8 new optional list inputs that complement the conceptual resources from #246. All default to `[]`, so existing consumers see no behavior change.

### New variables
- `area_paths`, `iteration_paths`
- `dashboards`, `feeds`, `wiki_pages`
- `pipeline_stages`, `pipeline_jobs`, `pipeline_variables`

These set the stage for upcoming for_each-style outputs in a follow-up PR; on their own they are no-ops.

## Validation
- ✅ `terraform fmt`
- ✅ `terraform validate`

Strictly additive. Part of v11 overhaul (Checkpoint 5).