### PR TITLE
🔧 chore(examples): bump module version constraint to v11

### DIFF
--- a/examples/example1/example.tf
+++ b/examples/example1/example.tf
@@ -1,6 +1,6 @@
 module "azdo_naming" {
   source  = "DownAtTheBottomOfTheMoleHole/naming/azuredevops"
-  version = ">= 6.0.0, <7.0.0"
+  version = ">= 11.0.0, < 12.0.0"
 
   # Optional variables
   environment_tags = [

--- a/examples/example2/example.tf
+++ b/examples/example2/example.tf
@@ -1,6 +1,6 @@
 module "azdo_naming" {
   source  = "DownAtTheBottomOfTheMoleHole/naming/azuredevops"
-  version = ">=6.0.0, <7.0.0"
+  version = ">= 11.0.0, < 12.0.0"
 
   # Optional variables
   environment_tags = [


### PR DESCRIPTION
## Summary

Bumps the version constraints in both example files from `>= 6.0.0, <7.0.0` to `>= 11.0.0, < 12.0.0` so that copy-pasted snippets line up with the v11 release.

## Files changed

- `examples/example1/example.tf`
- `examples/example2/example.tf`

Strictly an example refresh — no module behavior change.

Part of v11 overhaul (Checkpoint 8).
